### PR TITLE
Change submit input to non-submitting button

### DIFF
--- a/solutions/keyboard/keyboard-solution.html
+++ b/solutions/keyboard/keyboard-solution.html
@@ -36,7 +36,7 @@
                     <option value="advanced">advanced</option>
                 </select>    
                 <!-- Solution: used an HTML input type="submit" which is natively reachable and operable by keyboard -->
-                <input id="submit" type="submit" value="Submit" class="submit" onclick="alert('submitted')">  
+                <input id="button" type="button" value="Submit" class="submit" onclick="alert('submitted')">  
             </form>
              <!-- Solution: removed tabindex="0" -->
             <h2>Learn more about chess</h2>


### PR DESCRIPTION
Change the input type from submit to button. This prevents the form from performing a native submit while preserving the existing onclick alert handler.